### PR TITLE
Unreal 4.14.3 and Ubuntu Xenial support

### DIFF
--- a/Source/Unreal_ROS/Classes/CaptureActor.h
+++ b/Source/Unreal_ROS/Classes/CaptureActor.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Unreal_Ros.h"
+#include "Unreal_ROS.h"
 #include "Engine.h"
 #include "Engine/SceneCapture2D.h"
 #include <string>

--- a/Source/Unreal_ROS/Classes/ROSActorPublisher.h
+++ b/Source/Unreal_ROS/Classes/ROSActorPublisher.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Unreal_Ros.h"
+#include "Unreal_ROS.h"
 #include "TopicTemplate.h"
 #include "ros_msg_test.h"
 #include "ROSActorPublisher.generated.h"

--- a/Source/Unreal_ROS/Classes/ROSServoActors.h
+++ b/Source/Unreal_ROS/Classes/ROSServoActors.h
@@ -3,6 +3,7 @@
 #include "Unreal_ROS.h"
 #include "TopicTemplate.h"
 #include "ros_msg_test.h"
+#include "PhysicsEngine/PhysicsConstraintComponent.h"
 #include "ROSServoActors.generated.h"
 
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )

--- a/Source/Unreal_ROS/Unreal_ROS.Build.cs
+++ b/Source/Unreal_ROS/Unreal_ROS.Build.cs
@@ -7,16 +7,11 @@ namespace UnrealBuildTool.Rules
 {
     public class Unreal_ROS : ModuleRules
     {
-        private string ModulePath
-        {
-            get { return Path.GetDirectoryName(RulesCompiler.GetModuleFilename(this.GetType().Name)); }
-        }
-
         private string ThirdPartyPath
         {
             get
             {
-                return Path.GetFullPath(Path.Combine(ModulePath, "../../ThirdParty/"));
+                return Path.GetFullPath(Path.Combine(ModuleDirectory, "../../ThirdParty/"));
             }
         }
         public bool LoadOpenCV(TargetInfo Target)


### PR DESCRIPTION
Hi all,

on this PR some changes were made in order to make this project compile on Linux `Ubuntu 16.04` and work with `Unreal 4.14.x`.

To make it work on Linux, instead of importing `Unreal_Ros.h`, we are now importing `Unreal_ROS.h`.

And in order to make it work with Unreal `4.14.x`, we are including `PhysicsEngine/PhysicsConstraintComponent.h` on `ROSServoActors.h`. To achieve this, [this commit](https://github.com/LightOfSaturn/Unreal-ROS-Plugin/commit/dfea22a1220df26aded136929b7de0d189da5647) was used as reference.